### PR TITLE
added ALWAYS_SEARCH_USER_PATHS=NO to clean Xcode warnings

### DIFF
--- a/src/inhibit-warnings.js
+++ b/src/inhibit-warnings.js
@@ -8,6 +8,7 @@ function updateProject (project) {
 
 	project.addBuildProperty('GCC_WARN_INHIBIT_ALL_WARNINGS', 'YES');
 	project.addBuildProperty('RUN_CLANG_STATIC_ANALYZER', 'NO');
+	project.addBuildProperty('ALWAYS_SEARCH_USER_PATHS', 'NO');
 
 	const attributes = project.getFirstProject().firstProject.attributes;
 	attributes.LastUpgradeCheck = 9999;


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes



## Related issues (if any)

